### PR TITLE
addMultiValueInputTextField: do not change order of values

### DIFF
--- a/lam/lib/baseModule.inc
+++ b/lam/lib/baseModule.inc
@@ -1296,7 +1296,6 @@ abstract class baseModule {
 			if (sizeof($values) == 0) {
 				$values[] = '';
 			}
-			natcasesort($values);
 			$values = array_values($values);
 			if ($label !== null) {
 				$labelTextOut = new htmlOutputText($label);


### PR DESCRIPTION
I had the problem, that LAM changed the order of multi-value fields. With this little change the value order is retained.

I know, in fact the order of values in LDAP should not be relied upon as the order is undefined. It might be confusing to change the order anyway.

Is there a good reason for sorting the values before displaying?