### PR TITLE
missing setMarkAsRequired

### DIFF
--- a/lam/lib/baseModule.inc
+++ b/lam/lib/baseModule.inc
@@ -1305,6 +1305,7 @@ abstract class baseModule {
 			if ($label !== null) {
 				$labelTextOut = new htmlOutputText($label, true, $required);
 				$labelTextOut->alignment = htmlElement::ALIGN_TOP;
+				$labelTextOut->setMarkAsRequired($required);
 				$container->addElement($labelTextOut);
 			}
 			$subContainer = new htmlTable();


### PR DESCRIPTION
Same kind of missing call as before, in addMultiValueInputTextField this time.

Although, even after this patch, whenever submitting changes with an empty value on a required field (created via addMultiValueInputTextField), LAM seem to accept the changes and does not throw a warning.

Where in the code is the part actually checking for required fields ?

Cheers