### PR TITLE
keep container running

### DIFF
--- a/lam-packaging/docker/Dockerfile
+++ b/lam-packaging/docker/Dockerfile
@@ -52,5 +52,5 @@ RUN echo "RewriteEngine on" >> /etc/apache2/conf-enabled/laminit.conf \
  && echo "RewriteRule   ^/$  /lam/ [R,L]" >> /etc/apache2/conf-enabled/laminit.conf
 
 # start Apache when container starts
-ENTRYPOINT service apache2 start && /bin/bash
+ENTRYPOINT service apache2 start && sleep infinity
 


### PR DESCRIPTION
Hi, using ldapaccountmanager/lam in kubernetes stops running.
I think the same problem will happen starting using docker-compose.
Can you please change the Dockerfile or document on dockerhub.
Here is a config that works:
...
      containers:
        - name: ldap-account-manager
          image: ldapaccountmanager/lam
          command: ["/bin/sh"]
          args: ["-c", "service apache2 start && sleep infinity"]