### PR TITLE
General Dockerfile improvements & automatic configuration

### DIFF
--- a/lam-packaging/docker/.env
+++ b/lam-packaging/docker/.env
@@ -1,0 +1,10 @@
+LDAP_ORGANISATION="LDAP Account Manager Demo"
+LDAP_DOMAIN=mydomain.com
+LDAP_BASE_DN=dc=mydomain,dc=com
+LDAP_SERVER=ldap://ldap:389
+LDAP_ADMIN_PASSWORD=adminpw
+LDAP_READONLY_USER_PASSWORD=readonlypw
+LDAP_BIND_DN=cn=readonly,dc=mydomain,dc=com
+LDAP_SEARCH_BASE=dc=mydomain,dc=com
+
+LAM_PASSWORD=lam

--- a/lam-packaging/docker/Dockerfile
+++ b/lam-packaging/docker/Dockerfile
@@ -25,32 +25,59 @@
 #  You can change the port 8080 if needed.
 #
 
-FROM debian:stretch
-MAINTAINER Roland Gruber <post@rolandgruber.de>
+FROM debian:buster-slim
+LABEL maintainer="Roland Gruber <post@rolandgruber.de>"
 
 ARG LAM_RELEASE=6.9
 
-# update OS
-RUN apt-get update \
- && apt-get upgrade -y
+ENV \
+    DEBIAN_FRONTEND=noninteractive \
+    DEBUG=''
 
-# install requirements
-RUN apt-get install -y wget apache2 libapache2-mod-php php php-ldap php-zip php-xml php-curl php-gd php-imagick php-mcrypt php-tcpdf php-phpseclib fonts-dejavu php-monolog
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y \
+        apache2 \
+        ca-certificates \
+        dumb-init \
+        fonts-dejavu \
+        libapache2-mod-php \
+        php \
+        php-curl \
+        php-gd \
+        php-imagick \
+        php-ldap \
+        php-monolog \
+        php-phpseclib \
+        php-xml \
+        php-zip \
+        wget \
+    && \
+    rm /etc/apache2/sites-enabled/*default* && \
+    rm -rf /var/cache/apt /var/lib/apt/lists/*
 
 # install LAM
-RUN wget http://prdownloads.sourceforge.net/lam/ldap-account-manager_${LAM_RELEASE}-1_all.deb?download -O /tmp/ldap-account-manager_${LAM_RELEASE}-1_all.deb \
- && dpkg -i /tmp/ldap-account-manager_${LAM_RELEASE}-1_all.deb
+RUN wget http://prdownloads.sourceforge.net/lam/ldap-account-manager_${LAM_RELEASE}-1_all.deb?download \
+    -O /tmp/ldap-account-manager_${LAM_RELEASE}-1_all.deb && \
+    dpkg -i /tmp/ldap-account-manager_${LAM_RELEASE}-1_all.deb && \
+    rm -f /tmp/ldap-account-manager_${LAM_RELEASE}-1_all.deb
 
-# cleanup
-RUN apt-get autoremove -y && apt-get clean all \
- && rm -f /tmp/ldap-account-manager_${LAM_RELEASE}-1_all.deb \
- && rm /etc/apache2/sites-enabled/*default*
+# redirect Apache logging
+RUN sed -e 's,^ErrorLog.*,ErrorLog "|/bin/cat",' -i /etc/apache2/apache2.conf
+# because there is no logging set in the lam vhost logging goes to other_vhost_access.log
+RUN ln -sf /dev/stdout /var/log/apache2/other_vhosts_access.log
 
 # add redirect for /
 RUN a2enmod rewrite
 RUN echo "RewriteEngine on" >> /etc/apache2/conf-enabled/laminit.conf \
  && echo "RewriteRule   ^/$  /lam/ [R,L]" >> /etc/apache2/conf-enabled/laminit.conf
 
-# start Apache when container starts
-ENTRYPOINT service apache2 start && sleep infinity
+COPY start.sh /usr/local/bin/start.sh
 
+WORKDIR /var/lib/ldap-account-manager/config
+
+# start Apache when container starts
+ENTRYPOINT ["/usr/bin/dumb-init", "--"]
+CMD [ "/usr/local/bin/start.sh" ]
+
+HEALTHCHECK --interval=1m --timeout=10s \
+    CMD wget -qO- http://localhost/lam/ | grep -q '<title>LDAP Account Manager</title>'

--- a/lam-packaging/docker/docker-compose.yml
+++ b/lam-packaging/docker/docker-compose.yml
@@ -1,0 +1,45 @@
+version: '3.5'
+services:
+  ldap-account-manager:
+    build:
+      context: .
+      args:
+       - LAM_RELEASE=6.9
+    image: ldapaccountmanager/lam:latest
+    restart: unless-stopped
+    ports:
+      - "8080:80"
+    volumes:
+      - lametc/:/etc/ldap-account-manager
+      - lamconfig/:/var/lib/ldap-account-manager/config
+      - lamsession/:/var/lib/ldap-account-manager/sess
+    environment:
+      - LAM_PASSWORD=${LAM_PASSWORD}
+      - LAM_LANG=en_US
+      - LAM_TIMEZONE=Europe/Berlin
+      - LDAP_SERVER=${LDAP_SERVER}
+      - LDAP_DOMAIN=${LDAP_DOMAIN}
+      - LDAP_BASE_DN=${LDAP_BASE_DN}
+      - ADMIN_USER=cn=admin,${LDAP_BASE_DN}
+      - DEBUG=true
+  ldap:
+    image: osixia/openldap:latest
+    restart: unless-stopped
+    environment:
+      - LDAP_ORGANISATION=${LDAP_ORGANISATION}
+      - LDAP_DOMAIN=${LDAP_DOMAIN}
+      - LDAP_BASE_DN=${LDAP_BASE_DN}
+      - LDAP_ADMIN_PASSWORD=${LDAP_ADMIN_PASSWORD}
+      - LDAP_READONLY_USER=true
+      - LDAP_READONLY_USER_PASSWORD=${LDAP_READONLY_USER_PASSWORD}
+    command: "--loglevel info --copy-service"
+    volumes:
+      - ldap:/var/lib/ldap
+      - slapd:/etc/ldap/slapd.d
+
+volumes:
+  lametc:
+  lamconfig:
+  lamsession:
+  ldap:
+  slapd:

--- a/lam-packaging/docker/start.sh
+++ b/lam-packaging/docker/start.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+set -eu # unset variables are errors & non-zero return values exit the whole script
+[ "$DEBUG" ] && set -x
+
+LAM_LANG="${LAM_LANG:-en_US}"
+export LAM_PASSWORD="${LAM_PASSWORD:-lam}"
+LAM_PASSWORD_SSHA=$(php -r '$password = getenv("LAM_PASSWORD"); mt_srand((microtime() * 1000000)); $rand = abs(hexdec(bin2hex(openssl_random_pseudo_bytes(5)))); $salt0 = substr(pack("h*", md5($rand)), 0, 8); $salt = substr(pack("H*", sha1($salt0 . $password)), 0, 4); print "{SSHA}" . base64_encode(pack("H*", sha1($password . $salt))) . " " . base64_encode($salt) . "\n";')
+LAM_TIMEZONE="${LAM_TIMEZONE:-Europe/Berlin}"
+LDAP_HOST="${LDAP_HOST:-ldap://ldap:389}"
+LDAP_DOMAIN="${LDAP_DOMAIN:-mydomain.com}"
+LDAP_BASE_DN="${LDAP_BASE_DN:-dc=${LDAP_DOMAIN//\./,dc=}}"
+ADMIN_USER="${LDAP_USER:-cn=admin,${LDAP_BASE_DN}}"
+
+echo "Setting LAM password to: $LAM_PASSWORD"
+sed -i -f- /etc/ldap-account-manager/config.cfg <<- EOF
+	s|^password:.*|password: ${LAM_PASSWORD_SSHA}|;
+EOF
+unset LAM_PASSWORD
+
+sed -i -f- /var/lib/ldap-account-manager/config/lam.conf <<- EOF
+	s|^ServerURL:.*|ServerURL: ${LDAP_HOST}|;
+	s|^Admins:.*|Admins: ${ADMIN_USER}|;
+	s|^Passwd:.*|Passwd: ${LAM_PASSWORD_SSHA}|;
+	s|^treesuffix:.*|treesuffix: ${LDAP_BASE_DN}|;
+	s|^defaultLanguage:.*|defaultLanguage: ${LAM_LANG}.utf8|;
+	s|^types: suffix_user:.*|types: suffix_user: ${LDAP_BASE_DN}|;
+	s|^types: suffix_group:.*|types: suffix_group: ${LDAP_BASE_DN}|;
+EOF
+
+echo "Starting Apache"
+rm -f /run/apache2/apache2.pid
+set +u
+# shellcheck disable=SC1091
+source /etc/apache2/envvars
+exec /usr/sbin/apache2 -DFOREGROUND


### PR DESCRIPTION
Hi @gruberroland,

I am currently looking to integrate lam optionally into https://github.com/zokradonh/kopano-docker and therefore had the need to make the container dynamically configurable at startup.

Additionally I have added an example docker-compose.yml to simplify building and testing locally.

I am not yet completely done with my changes (once I am sure everything works as expected I also still want to upgrade to Buster), but already wanted to share my progress.

Once I am done I will also squash down the pr into a single commit.

Update: I am now happy with my changes, the only thing I could not easily do is going to Buster, since Buster is missing packages for 'php-mcrypt' and 'php-tcpdf'.

Let me know your thoughts.