### PR TITLE
Add 'expose 80' to Dockerfile

### DIFF
--- a/lam-packaging/docker/Dockerfile
+++ b/lam-packaging/docker/Dockerfile
@@ -30,6 +30,7 @@ FROM debian:buster-slim
 LABEL maintainer="Roland Gruber <post@rolandgruber.de>"
 
 ARG LAM_RELEASE=7.0
+EXPOSE 80
 
 ENV \
     DEBIAN_FRONTEND=noninteractive \


### PR DESCRIPTION
this made usage with seperate network and behind reverse proxies (traefik, nginx) easier