### PR TITLE
Add various opportunities to strengthen the instance

### DIFF
--- a/lam-packaging/docker/Dockerfile
+++ b/lam-packaging/docker/Dockerfile
@@ -99,7 +99,7 @@ RUN sed -e 's,^ErrorLog.*,ErrorLog "|/bin/cat",' -i /etc/apache2/apache2.conf
 RUN ln -sf /dev/stdout /var/log/apache2/other_vhosts_access.log
 
 # add redirect for /
-RUN a2enmod rewrite
+RUN a2enmod proxy proxy_http rewrite ssl
 RUN echo "RewriteEngine on" >> /etc/apache2/conf-enabled/laminit.conf \
  && echo "RewriteRule   ^/$  /lam/ [R,L]" >> /etc/apache2/conf-enabled/laminit.conf
 


### PR DESCRIPTION
Hello,

This PR adds the opportunity to strengthen the plain http connection. Additionally, into the apache config folder you can mount your own configuration.

Please take care for the healthcheck, which requires that http should be healthy also (option1: create and host on 2 virtualhost for 443 and 80; option2: host on 443 and redirect the http://localhost/lam with reverse proxy).  

Br,
cociweb