### PR TITLE
Quoting variables and using correct equality check

### DIFF
--- a/lam-packaging/docker/start.sh
+++ b/lam-packaging/docker/start.sh
@@ -21,7 +21,7 @@
 
 
 set -eu # unset variables are errors & non-zero return values exit the whole script
-[[ -n $DEBUG ]] && [[ $DEBUG -eq "true" ]] && set -x
+[[ -n "$DEBUG" ]] && [[ "$DEBUG" = "true" ]] && set -x
 
 if [ "${LAM_DISABLE_TLS_CHECK:-}" == "true" ]; then
   if ! grep -e '^TLS_REQCERT never$' /etc/ldap/ldap.conf > /dev/null; then


### PR DESCRIPTION
in start.sh, the equality check is incorrect and is causing failure to start with debugging set. -eq is used for numeric comparisons so it's getting into a weird state and trying to evalue the value of `$DEBUG` as a variable. 