### PR TITLE
add VEX file with vulnerabilities information to SBOM

### DIFF
--- a/lam/sbom.vex.json
+++ b/lam/sbom.vex.json
@@ -1,0 +1,70 @@
+{
+  "@context": "https://openvex.dev/ns/v0.2.0",
+  "@id": "https://openvex.dev/docs/public/vex-b6051162b0a9891901698e7a96945c2c2286529b4146719fca943937150bbd3b",
+  "author": "Unknown Author",
+  "timestamp": "2024-10-07T15:11:48.761178+02:00",
+  "last_updated": "2024-10-07T15:17:36.955082+02:00",
+  "version": 5,
+  "statements": [
+    {
+      "vulnerability": {
+        "name": "GHSA-457r-cqc8-9vj9"
+      },
+      "timestamp": "2024-10-07T15:11:48.761179+02:00",
+      "products": [
+        {
+          "@id": "pkg:npm/sweetalert2"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-mrr8-v49w-3333"
+      },
+      "timestamp": "2024-10-07T15:13:36.744754+02:00",
+      "products": [
+        {
+          "@id": "pkg:npm/sweetalert2"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-8jh9-wqpf-q52c"
+      },
+      "timestamp": "2024-10-07T15:15:07.044344+02:00",
+      "products": [
+        {
+          "@id": "pkg:npm/sweetalert2@8.19.1"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-pg98-6v7f-2xfv"
+      },
+      "timestamp": "2024-10-07T15:15:49.106046+02:00",
+      "products": [
+        {
+          "@id": "pkg:npm/sweetalert2@9.17.4"
+        }
+      ],
+      "status": "under_investigation"
+    },
+    {
+      "vulnerability": {
+        "name": "GHSA-qq6h-5g6j-q3cm"
+      },
+      "timestamp": "2024-10-07T15:17:36.955082+02:00",
+      "products": [
+        {
+          "@id": "pkg:npm/sweetalert2@11.4.9"
+        }
+      ],
+      "status": "under_investigation"
+    }
+  ]
+}


### PR DESCRIPTION
Dear project owners,
We are a group of researchers investigating the usefulness of augmenting Software Bills of Materials (SBOMs) with information about known vulnerabilities of third-party dependencies.

As claimed in previous interview-based studies, a major limitation—according to software practitioners—of existing SBOMs is the lack of information about known vulnerabilities.  For this reason, we would like to investigate how augmented SBOMs are received in open-source projects.

To this aim, we have identified popular open-source repositories on GitHub that provided SBOMs, statically detected vulnerabilities on their dependencies in the OSV database, and, based on its output, we have augmented your repository’s SBOM by leveraging the OpenVEX implementation of the Vulnerability Exploitability eXchange (VEX). 

The JSON file in this pull request consists of statements each indicating i) the software products (i.e., dependencies) that may be affected by a vulnerability. These are linked to the SBOM components through the @id field in their Persistent uniform resource locator (pURL); ii) a CVE affecting the product; iii) an impact status defined by VEX. By default, all statements have status `under_investigation` as it is not yet known whether these product versions are actually affected by the vulnerability. After investigating the vulnerability, further statuses can be `affected`, `not_affected`, `fixed`. It is possible to motivate the new status in a `justification` field (see https://www.cisa.gov/sites/default/files/publications/VEX_Status_Justification_Jun22.pdf for more information). 
 
We open this pull request containing a VEX file related to the SBOM of your project, and hope it will be considered. 
We would also like to hear your opinion on the usefulness (or not) of this information by answering a 3-minute anonymous survey:
https://ww2.unipark.de/uc/sbom/

Thanks in advance, and regards,
Davide Fucci (Blekinge Institute of Technology, Sweden) 
Simone Romano and Giuseppe Scaniello (University of Salerno, Italy),
Massimiliano Di Penta (University of Sannio, Italy)

