### PR TITLE
TLS with MySQL

### DIFF
--- a/lam/lib/config.inc
+++ b/lam/lib/config.inc
@@ -3064,6 +3064,9 @@ class LAMCfgMain {
 	/** database password */
 	public $configDatabasePassword = '';
 
+	/** database options */
+	public $configDatabaseSSLCA = '';
+
 	/** database password */
 	private $moduleSettings = '';
 
@@ -3080,14 +3083,14 @@ class LAMCfgMain {
 		'mailAttribute', 'mailBackupAttribute',
 		'configDatabaseType',
 		'configDatabaseServer', 'configDatabasePort', 'configDatabaseName', 'configDatabaseUser',
-		'configDatabasePassword', 'moduleSettings'
+		'configDatabasePassword', 'configDatabaseSSLCA', 'moduleSettings'
 	];
 
 	/** persistence settings are always stored on local file system */
 	private $persistenceSettings = [
 		'configDatabaseType', 'configDatabaseServer',
 		'configDatabasePort', 'configDatabaseName', 'configDatabaseUser',
-		'configDatabasePassword', 'license'
+		'configDatabasePassword', 'configDatabaseSSLCA', 'license'
 	];
 
 	/**

--- a/lam/lib/persistence.inc
+++ b/lam/lib/persistence.inc
@@ -918,7 +918,11 @@ class ConfigurationDatabase {
 			return $this->pdo;
 		}
 		$url = $this->getPdoUrl();
-		$this->pdo = new PDO($url, $this->cfgMain->configDatabaseUser, $this->cfgMain->configDatabasePassword, [PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION]);
+		$pdoAttr = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION);
+		if($this->cfgMain->configDatabaseSSLCA) {
+		  $pdoAttr = array(PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION, PDO::MYSQL_ATTR_SSL_CA => $this->cfgMain->configDatabaseSSLCA);
+		}
+		$this->pdo = new PDO($url, $this->cfgMain->configDatabaseUser, $this->cfgMain->configDatabasePassword, $pdoAttr);
 		return $this->pdo;
 	}
 

--- a/lam/templates/config/mainmanage.php
+++ b/lam/templates/config/mainmanage.php
@@ -139,6 +139,7 @@ if (isset($_POST['submitFormData'])) {
 		// set database
 		$cfg->configDatabaseType = $_POST['configDatabaseType'];
 		$cfg->configDatabaseServer = $_POST['configDatabaseServer'];
+		$cfg->configDatabaseSSLCA = $_POST['configDatabaseSSLCA'];
 		$cfg->configDatabasePort = $_POST['configDatabasePort'];
 		$cfg->configDatabaseName = $_POST['configDatabaseName'];
 		$cfg->configDatabaseUser = $_POST['configDatabaseUser'];
@@ -446,11 +447,11 @@ if (isset($_POST['submitFormData'])) {
 		$storageProviderSelect->setHasDescriptiveElements(true);
 		$dbRowsToShow = [
 			LAMCfgMain::DATABASE_FILE_SYSTEM => [],
-			LAMCfgMain::DATABASE_MYSQL => ['configDatabaseServer', 'configDatabasePort', 'configDatabaseName', 'configDatabaseUser', 'configDatabasePassword']
+			LAMCfgMain::DATABASE_MYSQL => ['configDatabaseServer', 'configDatabasePort', 'configDatabaseName', 'configDatabaseUser', 'configDatabasePassword', 'configDatabaseSSLCA']
 		];
 		$storageProviderSelect->setTableRowsToShow($dbRowsToShow);
 		$dbRowsToHide = [
-			LAMCfgMain::DATABASE_FILE_SYSTEM => ['configDatabaseServer', 'configDatabasePort', 'configDatabaseName', 'configDatabaseUser', 'configDatabasePassword'],
+			LAMCfgMain::DATABASE_FILE_SYSTEM => ['configDatabaseServer', 'configDatabasePort', 'configDatabaseName', 'configDatabaseUser', 'configDatabasePassword', 'configDatabaseSSLCA'],
 			LAMCfgMain::DATABASE_MYSQL => []
 		];
 		$storageProviderSelect->setTableRowsToHide($dbRowsToHide);
@@ -458,6 +459,8 @@ if (isset($_POST['submitFormData'])) {
 		$dbHost = new htmlResponsiveInputField(_('Database host'), 'configDatabaseServer', $cfg->configDatabaseServer, '273');
 		$dbHost->setRequired(true);
 		$row->add($dbHost);
+		$dbHostSSLCA = new htmlResponsiveInputField(_('Database host SSL CA'), 'configDatabaseSSLCA', $cfg->configDatabaseSSLCA, '276');
+		$row->add($dbHostSSLCA);
 		$dbPort = new htmlResponsiveInputField(_('Database port'), 'configDatabasePort', $cfg->configDatabasePort, '274');
 		$row->add($dbPort);
 		$dbName = new htmlResponsiveInputField(_('Database name'), 'configDatabaseName', $cfg->configDatabaseName, '276');


### PR DESCRIPTION
We needed a TLS secured connection to the MySQL database in one of our projects.

We added an additional field in the main config called configDatabaseSSLCA in lib/config.inc and changed the
code in getPdo so if this filed is set it will be added to the mysql connection in lib ersistence.inc.
For setting/changing the field we also changed templates/config/mainmanage.php and added it there.

I tested it in our project and it works.

Kinde regards, 

Thomas